### PR TITLE
Add scrollContainer to useEffect dependencies

### DIFF
--- a/src/ScrollProvider.js
+++ b/src/ScrollProvider.js
@@ -56,7 +56,7 @@ const ScrollProvider = ({
         scrollContainer.removeEventListener('scroll', onScroll, false);
       };
     },
-    [],
+    [scrollContainer],
   );
 
   return (


### PR DESCRIPTION
If we use useRef to reference the scrollContainer, we need to add it to the useEffect dependencies in order to reinitialize the event listener when the scrollContainer changes. Otherwise, the new scrollContainer will not have the event listener attached, and the scroll event will not be listened to.